### PR TITLE
Fix version file syntax

### DIFF
--- a/SafeBrakes/SafeBrakes.version
+++ b/SafeBrakes/SafeBrakes.version
@@ -15,7 +15,7 @@
         "MAJOR": 1,
         "MINOR": 7,
         "PATCH": 3
-    }
+    },
     "KSP_VERSION_MAX": {
         "MAJOR": 1,
         "MINOR": 7,


### PR DESCRIPTION
The latest version of this mod is failing to index in CKAN, [with this error](http://status.ksp-ckan.space/):

> After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION', line 19, position 4.

This is caused by a missing comma between `KSP_VERSION` and `KSP_VERSION_MAX`. This pull request adds the missing comma.